### PR TITLE
Delay navbar reveal with hero chrome

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -5,6 +5,7 @@ import { SplitText } from "gsap/SplitText";
 import { motion } from "motion/react";
 import { Signature } from "./Signature";
 import { useSiteSounds } from "../hooks/useSiteSounds";
+import { HERO_CHROME_REVEAL_DELAY } from "./animationTimings";
 
 if (typeof window !== "undefined") {
   gsap.registerPlugin(useGSAP, SplitText);
@@ -155,7 +156,7 @@ export default function Hero() {
       <motion.div
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ delay: 1.4, duration: 0.8 }}
+        transition={{ delay: HERO_CHROME_REVEAL_DELAY, duration: 0.8 }}
         className="absolute bottom-8 left-1/2 hidden -translate-x-1/2 flex-col items-center gap-2 text-xs uppercase tracking-[0.3em] text-muted sm:flex"
       >
         Scroll

--- a/components/HomeApp.tsx
+++ b/components/HomeApp.tsx
@@ -9,16 +9,16 @@ import { Footer } from "./Footer";
 
 export default function HomeApp() {
   return (
-      <div className="grain relative min-h-screen bg-body text-white">
-        <NavBar />
-        <main>
-          <Hero />
-          <About />
-          <Work />
-          <Skills />
-          <Contact />
-        </main>
-        <Footer />
-      </div>
+    <div className="grain relative min-h-screen bg-body text-white">
+      <NavBar />
+      <main>
+        <Hero />
+        <About />
+        <Work />
+        <Skills />
+        <Contact />
+      </main>
+      <Footer />
+    </div>
   );
 }

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { useSiteSounds } from "../hooks/useSiteSounds";
+import { HERO_CHROME_REVEAL_DELAY } from "./animationTimings";
 
 const BLOG_URL = "/blog/";
 const LINKEDIN_URL = "https://www.linkedin.com/in/aaryan-porwal/";
@@ -42,7 +43,12 @@ export default function NavBar() {
   }, []);
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50">
+    <motion.header
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: HERO_CHROME_REVEAL_DELAY, duration: 0.5 }}
+      className="fixed inset-x-0 top-0 z-50"
+    >
       <div
         className={`transition-all duration-500 ${
           scrolled
@@ -159,6 +165,6 @@ export default function NavBar() {
           </motion.div>
         )}
       </AnimatePresence>
-    </header>
+    </motion.header>
   );
 }

--- a/components/animationTimings.ts
+++ b/components/animationTimings.ts
@@ -1,0 +1,1 @@
+export const HERO_CHROME_REVEAL_DELAY = 1.4;


### PR DESCRIPTION
## Summary
- Add a shared hero chrome reveal delay constant.
- Use that delay for both the hero scroll cue and navbar fade-in.
- Keep the navbar mounted normally without hero readiness props or custom events.

## Testing
- bun run build