### PR TITLE
Reduce effect-driven state sync

### DIFF
--- a/components/CommandSwitcher.tsx
+++ b/components/CommandSwitcher.tsx
@@ -40,8 +40,6 @@ export default function CommandSwitcher({ commands }: Props) {
   const [query, setQuery] = useState("");
   const [activeIndex, setActiveIndex] = useState(0);
   const dialogRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
   const returnFocusRef = useRef<HTMLElement | null>(null);
 
   const filteredCommands = useMemo(() => {
@@ -50,26 +48,10 @@ export default function CommandSwitcher({ commands }: Props) {
 
     return commands.filter((command) => commandText(command).includes(needle));
   }, [commands, query]);
-
-  useEffect(() => {
-    setActiveIndex(0);
-  }, [query, open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const activeElement = document.getElementById(
-      `command-switcher-result-${activeIndex}`,
-    );
-    activeElement?.scrollIntoView({ block: "nearest" });
-  }, [activeIndex, open]);
-
-  useEffect(() => {
-    if (!open) return;
-
-    const id = window.setTimeout(() => inputRef.current?.focus(), 0);
-    return () => window.clearTimeout(id);
-  }, [open]);
+  const selectedIndex =
+    filteredCommands.length === 0
+      ? 0
+      : Math.min(activeIndex, filteredCommands.length - 1);
 
   function openSwitcher() {
     if (!open) {
@@ -78,6 +60,7 @@ export default function CommandSwitcher({ commands }: Props) {
           ? document.activeElement
           : null;
     }
+    setActiveIndex(0);
     setOpen(true);
   }
 
@@ -152,7 +135,7 @@ export default function CommandSwitcher({ commands }: Props) {
       }
 
       if (event.key === "Enter") {
-        const command = filteredCommands[activeIndex];
+        const command = filteredCommands[selectedIndex];
         if (!command) return;
 
         event.preventDefault();
@@ -166,7 +149,7 @@ export default function CommandSwitcher({ commands }: Props) {
       window.removeEventListener("command-switcher:open", onOpen);
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [activeIndex, filteredCommands, open]);
+  }, [filteredCommands, open, selectedIndex]);
 
   useEffect(() => {
     if (open) {
@@ -203,9 +186,12 @@ export default function CommandSwitcher({ commands }: Props) {
           <div className="flex items-center gap-3 border-b border-line bg-surface/70 px-4 py-3 sm:px-5">
             <span className="h-2.5 w-2.5 shrink-0 rounded-full bg-voltage" />
             <input
-              ref={inputRef}
               value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              onChange={(event) => {
+                setQuery(event.target.value);
+                setActiveIndex(0);
+              }}
+              autoFocus
               placeholder="Search"
               role="combobox"
               aria-autocomplete="list"
@@ -213,8 +199,8 @@ export default function CommandSwitcher({ commands }: Props) {
               className="min-w-0 flex-1 bg-transparent font-sans text-base text-white outline-none placeholder:text-muted"
               aria-controls="command-switcher-results"
               aria-activedescendant={
-                filteredCommands[activeIndex]
-                  ? `command-switcher-result-${activeIndex}`
+                filteredCommands[selectedIndex]
+                  ? `command-switcher-result-${selectedIndex}`
                   : undefined
               }
             />
@@ -224,17 +210,19 @@ export default function CommandSwitcher({ commands }: Props) {
           </div>
 
           <div
-            ref={listRef}
             id="command-switcher-results"
             role="listbox"
             className="max-h-[min(60vh,28rem)] overflow-y-auto overscroll-contain p-2"
           >
             {filteredCommands.length > 0 ? (
               filteredCommands.map((command, index) => {
-                const active = index === activeIndex;
+                const active = index === selectedIndex;
 
                 return (
                   <button
+                    ref={(element) => {
+                      if (active) element?.scrollIntoView({ block: "nearest" });
+                    }}
                     id={`command-switcher-result-${index}`}
                     key={`${command.section}-${command.href}`}
                     type="button"

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,5 +1,5 @@
 import type { KeyboardEvent, PointerEvent } from "react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import gsap from "gsap";
 import { useGSAP } from "@gsap/react";
 import { Draggable } from "gsap/Draggable";
@@ -47,24 +47,18 @@ export default function Contact() {
   const dragInstance = useRef<Draggable | null>(null);
   const chaseModeRef = useRef(false);
   const difficultyRef = useRef(4);
-  const [phase, setPhase] = useState<Phase>(STATE.IDLE);
+  const [phase, setPhaseState] = useState<Phase>(STATE.IDLE);
   const [chaseMode, setChaseMode] = useState(false);
   const [difficulty, setDifficulty] = useState(4);
   const phaseRef = useRef<Phase>(STATE.IDLE);
   const { tick, tap, off, shake, chime } = useSiteSounds();
 
-  useEffect(() => {
-    chaseModeRef.current = chaseMode;
-  }, [chaseMode]);
+  const setPhase = useCallback((nextPhase: Phase) => {
+    phaseRef.current = nextPhase;
+    setPhaseState(nextPhase);
 
-  useEffect(() => {
-    difficultyRef.current = difficulty;
-  }, [difficulty]);
-
-  useEffect(() => {
-    phaseRef.current = phase;
     if (!revealRef.current) return;
-    if (phase === STATE.APPROVED) {
+    if (nextPhase === STATE.APPROVED) {
       gsap.to(revealRef.current, {
         autoAlpha: 1,
         y: 0,
@@ -81,7 +75,7 @@ export default function Contact() {
         overwrite: "auto",
       });
     }
-  }, [phase]);
+  }, []);
 
   const setHeadFrame = useCallback((target: Phase) => {
     const map = {
@@ -136,7 +130,7 @@ export default function Contact() {
         },
       });
     }
-  }, [chime, resetCatPosition, setHeadFrame]);
+  }, [chime, resetCatPosition, setHeadFrame, setPhase]);
 
   const hasTreatReachedAnya = useCallback(() => {
     if (!bagRef.current || !catTargetRef.current) return false;
@@ -190,7 +184,7 @@ export default function Contact() {
         }
       },
     });
-  }, [hasTreatReachedAnya, setHeadFrame, shake, triggerApproval]);
+  }, [hasTreatReachedAnya, setHeadFrame, setPhase, shake, triggerApproval]);
 
   const resetToIdle = useCallback(() => {
     setPhase(STATE.IDLE);
@@ -206,7 +200,7 @@ export default function Contact() {
         ease: "expo.out",
       });
     }
-  }, [off, resetCatPosition, setHeadFrame]);
+  }, [off, resetCatPosition, setHeadFrame, setPhase]);
 
   const onChaseModeChange = (checked: boolean) => {
     tap();
@@ -399,6 +393,7 @@ export default function Contact() {
         dodgeAnyaFromPoint,
         moveTreatToAnya,
         setHeadFrame,
+        setPhase,
         shake,
         triggerApproval,
       ],

--- a/components/theme/ThemeMenu.tsx
+++ b/components/theme/ThemeMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { THEME_OPTIONS, type ThemeId } from "./theme";
 
 type ThemeMenuProps = {
@@ -50,21 +50,6 @@ export default function ThemeMenu({
   onSelect,
   onClose,
 }: ThemeMenuProps) {
-  const closeRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    closeRef.current?.focus();
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose, open]);
-
   useEffect(() => {
     if (!open) return;
 
@@ -80,6 +65,9 @@ export default function ThemeMenu({
   return (
     <div
       className="fixed inset-0 z-[110] flex items-start justify-center bg-body/75 px-4 py-20 backdrop-blur-md sm:px-6"
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
+      }}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -98,9 +86,9 @@ export default function ThemeMenu({
             Theme
           </h2>
           <button
-            ref={closeRef}
             type="button"
             aria-label="Close theme menu"
+            autoFocus
             onClick={onClose}
             className="grid h-9 w-9 place-items-center rounded-md border border-line text-muted transition-colors hover:border-voltage hover:text-voltage focus-visible:border-voltage focus-visible:text-voltage focus-visible:outline-none"
           >

--- a/components/theme/useTheme.ts
+++ b/components/theme/useTheme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   applyTheme,
   DEFAULT_THEME,
@@ -8,19 +8,25 @@ import {
 } from "./theme";
 
 export function useTheme(storageKey = THEME_STORAGE_KEY) {
-  const [theme, setThemeState] = useState<ThemeId>(DEFAULT_THEME);
+  const [theme, setThemeState] = useState<ThemeId>(() => {
+    if (typeof window === "undefined") return DEFAULT_THEME;
 
-  useEffect(() => {
-    const savedTheme = normalizeTheme(window.localStorage.getItem(storageKey));
-    setThemeState(savedTheme);
-    applyTheme(savedTheme);
-  }, [storageKey]);
+    try {
+      return normalizeTheme(window.localStorage.getItem(storageKey));
+    } catch {
+      return DEFAULT_THEME;
+    }
+  });
 
   const setTheme = useCallback(
     (nextTheme: ThemeId) => {
       setThemeState(nextTheme);
       applyTheme(nextTheme);
-      window.localStorage.setItem(storageKey, nextTheme);
+      try {
+        window.localStorage.setItem(storageKey, nextTheme);
+      } catch {
+        // The visual theme should still update when storage is unavailable.
+      }
     },
     [storageKey],
   );

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,7 @@
 declare module "*.css";
+
+interface Window {
+  posthog?: {
+    capture: (eventName: string, properties?: Record<string, unknown>) => void;
+  };
+}

--- a/packages/pattern-bank-theme-switcher/src/ThemeMenu.tsx
+++ b/packages/pattern-bank-theme-switcher/src/ThemeMenu.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect } from "react";
 import { THEME_OPTIONS, type ThemeId } from "./theme";
 
 export type ThemeMenuProps = {
@@ -24,7 +24,11 @@ function CheckIcon() {
   );
 }
 
-export function PaletteIcon({ className = "pbts-icon" }: { className?: string }) {
+export function PaletteIcon({
+  className = "pbts-icon",
+}: {
+  className?: string;
+}) {
   return (
     <svg
       aria-hidden="true"
@@ -52,21 +56,6 @@ export function ThemeMenu({
   onClose,
   className = "",
 }: ThemeMenuProps) {
-  const closeRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-
-    closeRef.current?.focus();
-
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
-    };
-
-    window.addEventListener("keydown", onKeyDown);
-    return () => window.removeEventListener("keydown", onKeyDown);
-  }, [onClose, open]);
-
   useEffect(() => {
     if (!open) return;
 
@@ -82,16 +71,35 @@ export function ThemeMenu({
   return (
     <div
       className={`pbts-overlay ${className}`.trim()}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") onClose();
+      }}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >
-      <div role="dialog" aria-modal="true" aria-labelledby="pbts-title" className="pbts-panel">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="pbts-title"
+        className="pbts-panel"
+      >
         <div className="pbts-header">
           <h2 id="pbts-title">Theme</h2>
-          <button ref={closeRef} type="button" aria-label="Close theme menu" onClick={onClose}>
+          <button
+            type="button"
+            aria-label="Close theme menu"
+            autoFocus
+            onClick={onClose}
+          >
             <svg aria-hidden="true" viewBox="0 0 20 20" className="pbts-icon">
-              <path d="m5 5 10 10M15 5 5 15" fill="none" stroke="currentColor" strokeLinecap="round" strokeWidth="2" />
+              <path
+                d="m5 5 10 10M15 5 5 15"
+                fill="none"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth="2"
+              />
             </svg>
           </button>
         </div>
@@ -115,7 +123,9 @@ export function ThemeMenu({
                 </span>
                 <span className="pbts-label-row">
                   <span>{option.label}</span>
-                  <span className={`pbts-check ${selected ? "is-selected" : ""}`}>
+                  <span
+                    className={`pbts-check ${selected ? "is-selected" : ""}`}
+                  >
                     {selected && <CheckIcon />}
                   </span>
                 </span>

--- a/packages/pattern-bank-theme-switcher/src/useTheme.ts
+++ b/packages/pattern-bank-theme-switcher/src/useTheme.ts
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import {
-  DEFAULT_THEME,
   getStoredTheme,
   setDocumentTheme,
   THEME_STORAGE_KEY,
@@ -11,14 +10,12 @@ export type UseThemeOptions = {
   storageKey?: string;
 };
 
-export function useTheme({ storageKey = THEME_STORAGE_KEY }: UseThemeOptions = {}) {
-  const [theme, setThemeState] = useState<ThemeId>(DEFAULT_THEME);
-
-  useEffect(() => {
-    const savedTheme = getStoredTheme(storageKey);
-    setThemeState(savedTheme);
-    setDocumentTheme(savedTheme);
-  }, [storageKey]);
+export function useTheme({
+  storageKey = THEME_STORAGE_KEY,
+}: UseThemeOptions = {}) {
+  const [theme, setThemeState] = useState<ThemeId>(() =>
+    getStoredTheme(storageKey),
+  );
 
   const setTheme = useCallback(
     (nextTheme: ThemeId) => {

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -31,7 +31,7 @@ export function postSummary(post: BlogPost) {
   if (post.data.description) return post.data.description;
   if (post.data.summary) return post.data.summary;
 
-  const plain = post.body
+  const plain = (post.body ?? "")
     .replace(/```[\s\S]*?```/g, "")
     .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
     .replace(/\[[^\]]+\]\([^)]+\)/g, (match) => {


### PR DESCRIPTION
Refactors the command switcher, contact interaction, and theme menus to avoid effect-driven state synchronization where direct state transitions or autofocus are sufficient. Theme hooks now initialize from storage directly and tolerate unavailable localStorage while still applying selected themes. The pattern-bank theme switcher receives the same menu and hook cleanup. Post summaries now handle missing bodies, and the global PostHog window type is declared.